### PR TITLE
Removed vgui_cache_res_files

### DIFF
--- a/cfg/valve.rc
+++ b/cfg/valve.rc
@@ -18,7 +18,6 @@ sv_unlockedchapters 99
 // Apply HUD settings
 cl_hud_minmode 0
 tf_use_match_hud 0
-vgui_cache_res_files 0
 //ce_teamscores_enabled 1					// Team score panels
 //ce_loadout_enabled 1						// Loadout icons
 //ce_hud_player_status_effects 1			// Player status effects (bleed, on-fire, etc.)


### PR DESCRIPTION
Setting vgui_cache_res_files to 0 outside of when reload the hud will cause lag spikes when rapidly switching the Engineer's PDA. https://github.com/CriticalFlaw/flawhud/issues/361