### PR TITLE
Fix up Fortress Faceoffs name and clean up

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,6 +1,6 @@
 ![image](https://user-images.githubusercontent.com/6818236/213952498-65c87d39-b4c7-4894-b72e-ee0e64712af1.png)
 
-Spectator HUD for Team Fortress 2, created by [EssentialsTF](https://essentials.tf/). Modified for Fortress Faceoff events.
+Spectator HUD for Team Fortress 2, created by [EssentialsTF](https://essentials.tf/). Modified for Fortress Faceoffs events.
 
 #### Acknowledgements
 - Original layout design by [WolfMachina](https://twitter.com/WolfMachina), [BlackOutJon](https://twitter.com/BlackOutJon) and [ArchRhythm](https://twitter.com/ArchRhythm).
@@ -9,8 +9,7 @@ Spectator HUD for Team Fortress 2, created by [EssentialsTF](https://essentials.
 - Fortress Faceoff layout design by [agrastiOs](https://github.com/agrastiOs).
 
 #### Notes
-- This is a public HUD that can be used for non-EssentialsTF events. We only ask that you remember to given credit in return.
-- To get the most out of this HUD's features, install the latest [CastingEssentials](https://github.com/dalegaard/CastingEssentials/releases) by [Phoenix Red](https://github.com/dalegaard).
+- This is a public HUD that can be used for non-EssentialsTF events. We kindly ask that you give credit in return whenever the hud is used in videos or live content.
+- To get the most out of this HUD's features, install the latest [CastingEssentialsNext](https://github.com/drunderscore/CastingEssentialsNext/) by [DrUnderscore](https://github.com/drunderscore/).
    - A list of CastingEssentials commands used with this HUD can be found [here](https://github.com/CriticalFlaw/essentialsHUD/wiki/Common-Commands).
-   - Delete the `resource` folder from your CastingEssentials installation. Not doing so will cause an incorrect team score panel to display.
-- For customization requests (such as those done for Seasonalander and Fortress Face-Off) please contact CriticalFlaw on Discord.
+- For customization requests (such as those done for Seasonalander and Fortress Faceoffs) please contact CriticalFlaw on Discord.


### PR DESCRIPTION
Removing the resource folder is no longer necessary as CastingEssentialsNext does not have the problematic files